### PR TITLE
Use slf4j's MessageFormatter correctly to format log messages with arguments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "avsl"
 
 organization := "org.clapper"
 
-version := "0.3.5"
+version := "0.3.6-SNAPSHOT"
 
 scalaVersion := "2.8.1"
 

--- a/src/main/scala/org/clapper/avsl/slf4j.scala
+++ b/src/main/scala/org/clapper/avsl/slf4j.scala
@@ -57,13 +57,13 @@ class AVSL_SLF4J_Logger(logger: Logger) extends MarkerIgnoringBase {
   def isDebugEnabled(): Boolean = logger.isDebugEnabled
 
   def debug(fmt: String, arg: Object): Unit =
-    if (isDebugEnabled) logger.debug(Formatter.format(fmt, arg))
+    if (isDebugEnabled) logger.debug(Formatter.format(fmt, arg).getMessage())
 
   def debug(fmt: String, args: Array[Object]): Unit =
-    if (isDebugEnabled) logger.debug(Formatter.format(fmt, args))
+    if (isDebugEnabled) logger.debug(Formatter.arrayFormat(fmt, args).getMessage())
 
   def debug(fmt: String, arg1: Object, arg2: Object): Unit =
-    if (isDebugEnabled) logger.debug(Formatter.format(fmt, arg1, arg2))
+    if (isDebugEnabled) logger.debug(Formatter.format(fmt, arg1, arg2).getMessage())
 
   def debug(msg: String): Unit = logger.debug(msg)
 
@@ -72,13 +72,13 @@ class AVSL_SLF4J_Logger(logger: Logger) extends MarkerIgnoringBase {
   def isErrorEnabled(): Boolean = logger.isErrorEnabled
 
   def error(fmt: String, arg: Object): Unit =
-    if (isErrorEnabled) logger.error(Formatter.format(fmt, arg))
+    if (isErrorEnabled) logger.error(Formatter.format(fmt, arg).getMessage())
 
   def error(fmt: String, args: Array[Object]): Unit =
-    if (isErrorEnabled) logger.error(Formatter.format(fmt, args))
+    if (isErrorEnabled) logger.error(Formatter.arrayFormat(fmt, args).getMessage())
 
   def error(fmt: String, arg1: Object, arg2: Object): Unit =
-    if (isErrorEnabled) logger.error(Formatter.format(fmt, arg1, arg2))
+    if (isErrorEnabled) logger.error(Formatter.format(fmt, arg1, arg2).getMessage())
 
   def error(msg: String): Unit = logger.error(msg)
 
@@ -87,13 +87,13 @@ class AVSL_SLF4J_Logger(logger: Logger) extends MarkerIgnoringBase {
   def isInfoEnabled(): Boolean = logger.isInfoEnabled
 
   def info(fmt: String, arg: Object): Unit =
-    if (isInfoEnabled) logger.info(Formatter.format(fmt, arg))
+    if (isInfoEnabled) logger.info(Formatter.format(fmt, arg).getMessage())
 
   def info(fmt: String, args: Array[Object]): Unit =
-    if (isInfoEnabled) logger.info(Formatter.format(fmt, args))
+    if (isInfoEnabled) logger.info(Formatter.arrayFormat(fmt, args).getMessage())
 
   def info(fmt: String, arg1: Object, arg2: Object): Unit =
-    if (isInfoEnabled) logger.info(Formatter.format(fmt, arg1, arg2))
+    if (isInfoEnabled) logger.info(Formatter.format(fmt, arg1, arg2).getMessage())
 
   def info(msg: String): Unit = logger.info(msg)
 
@@ -102,13 +102,13 @@ class AVSL_SLF4J_Logger(logger: Logger) extends MarkerIgnoringBase {
   def isTraceEnabled(): Boolean = logger.isTraceEnabled
 
   def trace(fmt: String, arg: Object): Unit =
-    if (isTraceEnabled) logger.trace(Formatter.format(fmt, arg))
+    if (isTraceEnabled) logger.trace(Formatter.format(fmt, arg).getMessage())
 
   def trace(fmt: String, args: Array[Object]): Unit =
-    if (isTraceEnabled) logger.trace(Formatter.format(fmt, args))
+    if (isTraceEnabled) logger.trace(Formatter.arrayFormat(fmt, args).getMessage())
 
   def trace(fmt: String, arg1: Object, arg2: Object): Unit =
-    if (isTraceEnabled) logger.trace(Formatter.format(fmt, arg1, arg2))
+    if (isTraceEnabled) logger.trace(Formatter.format(fmt, arg1, arg2).getMessage())
 
   def trace(msg: String): Unit = logger.trace(msg)
 
@@ -117,13 +117,13 @@ class AVSL_SLF4J_Logger(logger: Logger) extends MarkerIgnoringBase {
   def isWarnEnabled(): Boolean = logger.isWarnEnabled
 
   def warn(fmt: String, arg: Object): Unit =
-    if (isWarnEnabled) logger.warn(Formatter.format(fmt, arg))
+    if (isWarnEnabled) logger.warn(Formatter.format(fmt, arg).getMessage())
 
   def warn(fmt: String, args: Array[Object]): Unit =
-    if (isWarnEnabled) logger.warn(Formatter.format(fmt, args))
+    if (isWarnEnabled) logger.warn(Formatter.arrayFormat(fmt, args).getMessage())
 
   def warn(fmt: String, arg1: Object, arg2: Object): Unit =
-    if (isWarnEnabled) logger.warn(Formatter.format(fmt, arg1, arg2))
+    if (isWarnEnabled) logger.warn(Formatter.format(fmt, arg1, arg2).getMessage())
 
   def warn(msg: String): Unit = logger.warn(msg)
 

--- a/src/test/scala/slf4j.scala
+++ b/src/test/scala/slf4j.scala
@@ -98,6 +98,15 @@ class SLF4JTest extends FlatSpec with ShouldMatchers {
              handler.getClass.getName)
     }
 
+    def test(expected: String)(logAction: Logger => Unit) {
+      inMemoryHandler.clear
+
+      logAction(slf4jLogger)
+
+      inMemoryHandler.buf.length should equal (1)
+      inMemoryHandler.buf(0) should equal (expected)
+    }
+
     val data: List[(String, LogLevel, String)] = List(
       ("test", LogLevel.Info, "(INFO) " + LoggerName + " test"),
       ("foo bar", LogLevel.Error, "(ERROR) " + LoggerName + " foo bar"),
@@ -105,18 +114,37 @@ class SLF4JTest extends FlatSpec with ShouldMatchers {
     )
 
     for ((message, level, result) <- data) {
-      inMemoryHandler.clear
-      level match {
-        case LogLevel.Error => slf4jLogger.error(message)
-        case LogLevel.Warn  => slf4jLogger.warn(message)
-        case LogLevel.Info  => slf4jLogger.info(message)
-        case LogLevel.Debug => slf4jLogger.debug(message)
-        case LogLevel.Trace => slf4jLogger.trace(message)
-        case _              => fail("Unknown level: " + level)
+      test(result) { slf4jLogger =>
+        level match {
+          case LogLevel.Error => slf4jLogger.error(message)
+          case LogLevel.Warn  => slf4jLogger.warn(message)
+          case LogLevel.Info  => slf4jLogger.info(message)
+          case LogLevel.Debug => slf4jLogger.debug(message)
+          case LogLevel.Trace => slf4jLogger.trace(message)
+          case _              => fail("Unknown level: " + level)
+        }
       }
-
-      inMemoryHandler.buf.length should equal (1)
-      inMemoryHandler.buf(0) should equal (result)
     }
+
+    test("(ERROR) " + LoggerName + " args: (none)")         { _.error("args: (none)") }
+    test("(ERROR) " + LoggerName + " args: arg1")           { _.error("args: {}", "arg1") }
+    test("(ERROR) " + LoggerName + " args: arg1 arg2")      { _.error("args: {} {}", "arg1", "arg2") }
+    test("(ERROR) " + LoggerName + " args: arg1 arg2 arg3") { _.error("args: {} {} {}", Array[Object]("arg1", "arg2", "arg3")) }
+    test("(WARN) "  + LoggerName + " args: (none)")         { _.warn ("args: (none)") }
+    test("(WARN) "  + LoggerName + " args: arg1")           { _.warn ("args: {}", "arg1") }
+    test("(WARN) "  + LoggerName + " args: arg1 arg2")      { _.warn ("args: {} {}", "arg1", "arg2") }
+    test("(WARN) "  + LoggerName + " args: arg1 arg2 arg3") { _.warn ("args: {} {} {}", Array[Object]("arg1", "arg2", "arg3")) }
+    test("(INFO) "  + LoggerName + " args: (none)")         { _.info ("args: (none)") }
+    test("(INFO) "  + LoggerName + " args: arg1")           { _.info ("args: {}", "arg1") }
+    test("(INFO) "  + LoggerName + " args: arg1 arg2")      { _.info ("args: {} {}", "arg1", "arg2") }
+    test("(INFO) "  + LoggerName + " args: arg1 arg2 arg3") { _.info ("args: {} {} {}", Array[Object]("arg1", "arg2", "arg3")) }
+    test("(DEBUG) " + LoggerName + " args: (none)")         { _.debug("args: (none)") }
+    test("(DEBUG) " + LoggerName + " args: arg1")           { _.debug("args: {}", "arg1") }
+    test("(DEBUG) " + LoggerName + " args: arg1 arg2")      { _.debug("args: {} {}", "arg1", "arg2") }
+    test("(DEBUG) " + LoggerName + " args: arg1 arg2 arg3") { _.debug("args: {} {} {}", Array[Object]("arg1", "arg2", "arg3")) }
+    test("(TRACE) " + LoggerName + " args: (none)")         { _.trace("args: (none)") }
+    test("(TRACE) " + LoggerName + " args: arg1")           { _.trace("args: {}", "arg1") }
+    test("(TRACE) " + LoggerName + " args: arg1 arg2")      { _.trace("args: {} {}", "arg1", "arg2") }
+    test("(TRACE) " + LoggerName + " args: arg1 arg2 arg3") { _.trace("args: {} {} {}", Array[Object]("arg1", "arg2", "arg3")) }
   }
 }


### PR DESCRIPTION
Fixes messages like `(WARN) org.clapper.avsl org.slf4j.helpers.FormattingTuple@3cf44549` to the correct `(WARN) org.clapper.avsl args: arg1` (see test cases).
