### PR TITLE
Fix reversed %h and %H in docs

### DIFF
--- a/api/org/clapper/avsl/formatter/SimpleFormatter.html
+++ b/api/org/clapper/avsl/formatter/SimpleFormatter.html
@@ -43,8 +43,8 @@ literally. Many of the escapes are borrowed directly from <code>strftime()</code
 - %d: the day of the month
 - %D: equivalent to %m/%d/%y
 - %F: equivalent to %Y/%m/%d
-- %h: the hour of the day (0-23)
-- %H: the hour of the day (1-12)
+- %h: the hour of the day (1-12)
+- %H: the hour of the day (0-23)
 - %j: the day of the year (i.e., the so-called Julian day)
 - %l: the log level name (e.g., &quot;INFO&quot;, &quot;DEBUG&quot;)
 - %L: the log level's numeric value

--- a/users-guide.md
+++ b/users-guide.md
@@ -561,8 +561,8 @@ literally. Many of the escapes are borrowed directly from `strftime()`.
 - `%d`: the day of the month
 - `%D`: equivalent to %m/%d/%y
 - `%F`: equivalent to %Y/%m/%d
-- `%h`: the hour of the day (0-23)
-- `%H`: the hour of the day (1-12)
+- `%h`: the hour of the day (1-12)
+- `%H`: the hour of the day (0-23)
 - `%j`: the day of the year (i.e., the so-called Julian day)
 - `%l`: the log level name (e.g., "INFO", "DEBUG")
 - `%L`: the log level's numeric value


### PR DESCRIPTION
The user guide (http://software.clapper.org/avsl/users-guide.html) states that `%h` is the hour of the day from 0-23 and `%H` is the hour 1-12, but actually they are reversed.
